### PR TITLE
Migrate rabbitmq to ComputeTokens

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/cyrilgdn/terraform-provider-rabbitmq v0.0.0-00010101000000-000000000000
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.125.0
 	github.com/pulumi/pulumi/sdk/v3 v3.226.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
@@ -58,6 +59,7 @@ require (
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/deckarep/golang-set/v2 v2.5.0 // indirect
 	github.com/djherbis/times v1.6.0 // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
@@ -146,6 +148,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
 	github.com/pulumi/esc v0.23.0 // indirect

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cyrilgdn/terraform-provider-rabbitmq/rabbitmq"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	tftokens "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 
@@ -86,10 +87,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 		},
 		Resources: map[string]*tfbridge.ResourceInfo{
-			"rabbitmq_binding":  {Tok: makeResource(mainMod, "Binding")},
-			"rabbitmq_exchange": {Tok: makeResource(mainMod, "Exchange")},
 			"rabbitmq_permissions": {
-				Tok: makeResource(mainMod, "Permissions"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"permissions": {
 						CSharpName: "PermissionDetails",
@@ -97,31 +95,25 @@ func Provider() tfbridge.ProviderInfo {
 				},
 			},
 			"rabbitmq_policy": {
-				Tok: makeResource(mainMod, "Policy"),
 				Fields: map[string]*tfbridge.SchemaInfo{
 					"policy": {
 						CSharpName: "PolicyBlock",
 					},
 				},
 			},
-			"rabbitmq_queue": {Tok: makeResource(mainMod, "Queue")},
-			"rabbitmq_user":  {Tok: makeResource(mainMod, "User")},
+			// Preserve the long-standing VHost token casing instead of the default Vhost.
 			"rabbitmq_vhost": {Tok: makeResource(mainMod, "VHost")},
 			"rabbitmq_topic_permissions": {
-				Tok: makeResource(mainMod, "TopicPermissions"),
 				Docs: &tfbridge.DocInfo{
 					Source: "topic-permissions.html.markdown",
 				},
 			},
 			"rabbitmq_federation_upstream": {
-				Tok: makeResource(mainMod, "FederationUpstream"),
 				Docs: &tfbridge.DocInfo{
 					Source: "federation-upstream.html.markdown",
 				},
 			},
-			"rabbitmq_shovel": {Tok: makeResource(mainMod, "Shovel")},
 			"rabbitmq_operator_policy": {
-				Tok: makeResource(mainMod, "OperatorPolicy"),
 				Docs: &tfbridge.DocInfo{
 					Source: "operator-policy.html.markdown",
 				},
@@ -129,18 +121,16 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		DataSources: map[string]*tfbridge.DataSourceInfo{
 			"rabbitmq_exchange": {
-				Tok:  makeDataSource(mainMod, "getExchange"),
 				Docs: noDocs,
 			},
 			"rabbitmq_user": {
-				Tok:  makeDataSource(mainMod, "getUser"),
 				Docs: noDocs,
 			},
 			"rabbitmq_default_user": {
-				Tok:  makeDataSource(mainMod, "getDefaultUser"),
 				Docs: noDocs,
 			},
 			"rabbitmq_vhost": {
+				// Preserve the long-standing getVHost token casing instead of getVhost.
 				Tok:  makeDataSource(mainMod, "getVHost"),
 				Docs: noDocs,
 			},
@@ -182,6 +172,11 @@ func Provider() tfbridge.ProviderInfo {
 		},
 	}
 
+	prov.MustComputeTokens(tftokens.SingleModule(
+		prov.GetResourcePrefix(),
+		mainMod,
+		tftokens.MakeStandard(mainPkg),
+	))
 	prov.SetAutonaming(255, "-")
 
 	return prov

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -1,0 +1,78 @@
+package rabbitmq
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-rabbitmq/provider/v3/pkg/version"
+)
+
+func TestProviderPreservesExistingTokens(t *testing.T) {
+	prov := testProvider(t)
+
+	expectedResources := map[string]string{
+		"rabbitmq_binding":             "rabbitmq:index/binding:Binding",
+		"rabbitmq_exchange":            "rabbitmq:index/exchange:Exchange",
+		"rabbitmq_permissions":         "rabbitmq:index/permissions:Permissions",
+		"rabbitmq_policy":              "rabbitmq:index/policy:Policy",
+		"rabbitmq_queue":               "rabbitmq:index/queue:Queue",
+		"rabbitmq_user":                "rabbitmq:index/user:User",
+		"rabbitmq_vhost":               "rabbitmq:index/vHost:VHost",
+		"rabbitmq_topic_permissions":   "rabbitmq:index/topicPermissions:TopicPermissions",
+		"rabbitmq_federation_upstream": "rabbitmq:index/federationUpstream:FederationUpstream",
+		"rabbitmq_shovel":              "rabbitmq:index/shovel:Shovel",
+		"rabbitmq_operator_policy":     "rabbitmq:index/operatorPolicy:OperatorPolicy",
+	}
+
+	expectedDataSources := map[string]string{
+		"rabbitmq_exchange":     "rabbitmq:index/getExchange:getExchange",
+		"rabbitmq_user":         "rabbitmq:index/getUser:getUser",
+		"rabbitmq_default_user": "rabbitmq:index/getDefaultUser:getDefaultUser",
+		"rabbitmq_vhost":        "rabbitmq:index/getVHost:getVHost",
+	}
+
+	for tfToken, expected := range expectedResources {
+		info, ok := prov.Resources[tfToken]
+		require.Truef(t, ok, "missing resource mapping for %s", tfToken)
+		require.Equal(t, expected, string(info.Tok))
+	}
+
+	for tfToken, expected := range expectedDataSources {
+		info, ok := prov.DataSources[tfToken]
+		require.Truef(t, ok, "missing data source mapping for %s", tfToken)
+		require.Equal(t, expected, string(info.Tok))
+	}
+}
+
+func TestProviderComputesTokensForAllTerraformElements(t *testing.T) {
+	prov := testProvider(t)
+
+	prov.P.ResourcesMap().Range(func(tfToken string, _ shim.Resource) bool {
+		info, ok := prov.Resources[tfToken]
+		require.Truef(t, ok, "missing resource mapping for %s", tfToken)
+		require.NotEmptyf(t, info.Tok, "missing resource token for %s", tfToken)
+		return true
+	})
+
+	prov.P.DataSourcesMap().Range(func(tfToken string, _ shim.Resource) bool {
+		info, ok := prov.DataSources[tfToken]
+		require.Truef(t, ok, "missing data source mapping for %s", tfToken)
+		require.NotEmptyf(t, info.Tok, "missing data source token for %s", tfToken)
+		return true
+	})
+}
+
+func testProvider(t *testing.T) tfbridge.ProviderInfo {
+	t.Helper()
+
+	oldVersion := version.Version
+	version.Version = "3.0.0"
+	t.Cleanup(func() {
+		version.Version = oldVersion
+	})
+
+	return Provider()
+}

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -3,9 +3,10 @@ package rabbitmq
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
-	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi-rabbitmq/provider/v3/pkg/version"
 )


### PR DESCRIPTION
## Summary
- switch the provider token mapping over to `MustComputeTokens(tokens.SingleModule(...))`
- keep explicit overrides only where needed for backward compatibility and custom metadata, including the existing `VHost` / `getVHost` casing
- add provider tests that lock the existing public tokens and ensure every Terraform resource and data source gets a Pulumi token

Closes #765.

## Testing
- `cd provider && go test ./...`
- `make schema`
- `make build_sdks` (Node.js, Python, .NET, and Go completed; Java stopped locally because `gradle` was not installed in this environment)